### PR TITLE
Cambios

### DIFF
--- a/recordspage.h
+++ b/recordspage.h
@@ -36,6 +36,12 @@ public slots:
     void navNext();
     void navLast();
 
+    // --- Ordenación desde Ribbon ---
+    void sortAscending();
+    void sortDescending();
+    void clearSorting();
+
+
 private slots:
     // Encabezado / acciones
     void onTablaChanged(int index);


### PR DESCRIPTION
1. Navegación real en RecordsPage (bloqueante de build actual):

shellwindow.cpp ya se conecta a una señal RecordsPage::navState(int cur,int tot,bool canPrev,bool canNext), pero esa señal aún no existe en RecordsPage → esto rompe la compilación.

2. Faltan los métodos/slots navFirst, navPrev, navNext, navLast en RecordsPage para mover la selección y emitir navState (y actualizar “x of y” y habilitar/deshabilitar botones).

3. Ordenar desde el Ribbon:

Botones “Sort Asc/Desc/Clear” del ribbon solo muestran icono; falta cablearlos a:

twRegistros->sortByColumn(col, Qt::AscendingOrder/DescendingOrder).

Elegir col (p.ej., columna seleccionada o 0 si ninguna) y un “Clear” (desactivar orden).

4. Toggle “Filter” del navigator:

Hoy solo cambia el icono/texto. Opcional: hacerlo funcional (p.ej., aplicar/retirar el término del cuadro de búsqueda o activar un QSortFilterProxy).

5. Navegación y contador con filas ocultas por filtro:

La navegación debería considerar solo filas visibles al calcular cur/tot y saltar entre visibles.